### PR TITLE
Provider tests output console to txt file

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -78,12 +78,6 @@ steps:
     PathtoPublish: '$(System.DefaultWorkingDirectory)/src/Tests/Contract/pacts/SchoolDempApi.Client-SchoolDemoApi.json'
     ArtifactName: 'drop'
     publishLocation: 'Container'
-
-- task: PowerShell@2
-  inputs:
-    targetType: 'inline'
-    script: '[Environment]::SetEnvironmentVariable("HARRI_PROVIDER_PACT_PATH", "$(System.DefaultWorkingDirectory)\src\Tests\Contract\pacts\SchoolDempApi.Client-SchoolDemoApi.json", "User")'
-    failOnStderr: true
     
 
 #- task: VSTest@2

--- a/src/Tests/Contract/Harri.SchoolDemoAPI.Tests.Contract.Provider/Provider/ProviderTests.cs
+++ b/src/Tests/Contract/Harri.SchoolDemoAPI.Tests.Contract.Provider/Provider/ProviderTests.cs
@@ -17,11 +17,12 @@ namespace Harri.SchoolDemoAPI.Tests.Contract.Provider
             _provider = new MockedHostedProvider();
 
             //This environment variable should only be set on build agents
-            _providerPactPath = Environment.GetEnvironmentVariable("HARRI_PROVIDER_PACT_PATH", EnvironmentVariableTarget.User);
-
+            _providerPactPath = Environment.GetEnvironmentVariable("HARRI_PROVIDER_PACT_PATH");
+            Console.WriteLine($"Provider Env Var: {_providerPactPath}");
             if (_providerPactPath != null )
             {
                 _writer = new StreamWriter($"{TestContext.CurrentContext.WorkDirectory}/{TestConsoleOutputFile}");
+                
                 Console.SetOut(_writer);
             }
         }

--- a/src/Tests/Contract/Harri.SchoolDemoAPI.Tests.Contract.Provider/Provider/ProviderTests.cs
+++ b/src/Tests/Contract/Harri.SchoolDemoAPI.Tests.Contract.Provider/Provider/ProviderTests.cs
@@ -9,7 +9,8 @@ namespace Harri.SchoolDemoAPI.Tests.Contract.Provider
         private MockedHostedProvider _provider;
         private TextWriter? _writer;
         private string? _providerPactPath;
-        private const string TestConsoleOutputFile = "ProviderTestsOutput.txt";
+        private const string ProviderTestsOutputFileName = "ProviderTestsOutput.txt";
+        private string ProviderTestOutputFullPath => $"{TestContext.CurrentContext.WorkDirectory}/{ProviderTestsOutputFileName}";
 
         [SetUp]
         public void SetUp()
@@ -18,10 +19,9 @@ namespace Harri.SchoolDemoAPI.Tests.Contract.Provider
 
             //This environment variable should only be set on build agents
             _providerPactPath = Environment.GetEnvironmentVariable("HARRI_PROVIDER_PACT_PATH");
-            Console.WriteLine($"Provider Env Var: {_providerPactPath}");
             if (_providerPactPath != null )
             {
-                _writer = new StreamWriter($"{TestContext.CurrentContext.WorkDirectory}/{TestConsoleOutputFile}");
+                _writer = new StreamWriter(ProviderTestOutputFullPath);
                 
                 Console.SetOut(_writer);
             }
@@ -31,10 +31,11 @@ namespace Harri.SchoolDemoAPI.Tests.Contract.Provider
         public void TearDown() 
         {
             _provider.Dispose();
-            _writer.Close();
+
             if (_providerPactPath != null)
             {
-                TestContext.AddTestAttachment($"{TestContext.CurrentContext.WorkDirectory}/{TestConsoleOutputFile}");
+                _writer?.Close();
+                TestContext.AddTestAttachment(ProviderTestOutputFullPath);
             }
         }
 


### PR DESCRIPTION
This txt file is visible under the test results for successful provider test runs.

![image](https://github.com/HarrisonSlater/Harri.SchoolDemoApi/assets/32419991/4b3d3ba8-5365-48a6-98c6-3584c5f8698a)
